### PR TITLE
Clean up linters (cpplint, uncrustify, flake8)

### DIFF
--- a/include/JustInterp/CPPLINT.cfg
+++ b/include/JustInterp/CPPLINT.cfg
@@ -1,0 +1,1 @@
+exclude_files=JustInterp.hpp

--- a/include/JustInterp/JustInterp.hpp
+++ b/include/JustInterp/JustInterp.hpp
@@ -18,6 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+// Skip uncrustify linting
+/* *INDENT-OFF* */
 
 #pragma once
 
@@ -207,10 +209,10 @@ public:
 
     /********************************************************************
      * @brief Set known data points and values.
-     * 
+     *
      * Container must have real-type values and the following methods:
      * data(), size(), begin(), end()
-     * 
+     *
      * @param[in] x Known points array
      * @param[in] y Known values array
      *********************************************************************/
@@ -243,10 +245,10 @@ public:
 
     /********************************************************************
      * @brief Calculate interpolation function at each point of given array.
-     * 
+     *
      * Container must have real-type values and the following methods:
      * data(), size(), begin(), end()
-     * 
+     *
      * @param[in] x Array of points to interpolate
      * @return std::vector<Real> of interpolated values
      *********************************************************************/
@@ -298,7 +300,7 @@ private:
 private:
 
     std::vector<Real> xData_, yData_;
-    
+
 };
 
 }
@@ -353,10 +355,10 @@ public:
 
     /********************************************************************
      * @brief Set known grid points and values.
-     * 
+     *
      * Container must have real-type values and the following methods:
      * data(), size(), begin(), end()
-     * 
+     *
      * @param[in] x_1d Grid points along x-axis
      * @param[in] y_1d Grid points along y-axis
      * @param[in] z_all All node values stored as 1d array
@@ -400,10 +402,10 @@ public:
     /********************************************************************
      * Calculate interpolation function at each given points.
      * If some points are outside the data extrapolation is performed.
-     * 
+     *
      * Container must have real-type values and the following methods:
      * data(), size(), begin(), end()
-     * 
+     *
      * @param[in] x Array of x-coordinate. x.size() must be equals y.size()
      * @param[in] y Array of y-coordinate. x.size() must be equals y.size()
      * @return std::vector<Real> of interpolated values
@@ -422,13 +424,13 @@ public:
     }
 
     /********************************************************************
-     * Calculate interpolation function for 2D grid. 2D grid is defined 
-     * by two 1D arrays of coordinates along the x-axis and y-axis respectively. 
+     * Calculate interpolation function for 2D grid. 2D grid is defined
+     * by two 1D arrays of coordinates along the x-axis and y-axis respectively.
      * 1D result array is stored according to StorageOrder_.
-     * 
+     *
      * Container must have real-type values and the following methods:
      * data(), size(), begin(), end()
-     * 
+     *
      * @param[in] x_1d Grid coordinates along x-axis
      * @param[in] y_1d Grid coordinates along y-axis
      * @return std::vector<Real> of interpolated values stored according to StorageOrder_
@@ -465,9 +467,9 @@ private:
     /********************************************************************
      * Calculate interpolation function at the given point (x, y)
      * for given rectangle (ix, iy) - left-bottom corner index
-     * 
+     *
      * @see https://en.wikipedia.org/wiki/Bilinear_interpolation
-     * 
+     *
      * @param[in] x X-coordinate
      * @param[in] y Y-coordinate
      * @return Interpolated value
@@ -608,7 +610,7 @@ public:
     /********************************************************************
      * @brief Set known data points and values.
      * @param[in] x_1d 1D array of points along x-axis
-     * @param[in] y_1d_arrays Array of 1D arrays of points along y-axis 
+     * @param[in] y_1d_arrays Array of 1D arrays of points along y-axis
      *                        for corresponding point from x_1d
      * @param[in] z_1d_arrays Array of 1D arrays of values for corresponding
      *                        points from x_1d and y_1d_arrays
@@ -682,10 +684,10 @@ public:
     /********************************************************************
      * Calculate interpolation function at each given points.
      * If some points are outside the data extrapolation is performed.
-     * 
+     *
      * Container must have real-type values and the following methods:
      * data(), size(), begin(), end()
-     * 
+     *
      * @param[in] x Array of x-coordinate. x.size() must be equals y.size()
      * @param[in] y Array of y-coordinate. x.size() must be equals y.size()
      * @return std::vector<Real> of interpolated values
@@ -711,3 +713,5 @@ private:
 };
 
 }
+
+/* *INDENT-ON* */

--- a/launch/torque_controller.launch.py
+++ b/launch/torque_controller.launch.py
@@ -17,6 +17,7 @@ from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch_ros.actions import Node
 
+
 def generate_launch_description():
     ld = LaunchDescription()
     config = os.path.join(
@@ -25,11 +26,11 @@ def generate_launch_description():
         'pb_torque_controller.yaml'
         )
 
-    node=Node(
-        package = 'buoy_examples',
-        name = 'pb_torque_controller',
-        executable = 'torque_controller',
-        parameters = [config]
+    node = Node(
+        package='buoy_examples',
+        name='pb_torque_controller',
+        executable='torque_controller',
+        parameters=[config]
     )
 
     ld.add_action(node)

--- a/src/torque_controller.cpp
+++ b/src/torque_controller.cpp
@@ -40,9 +40,9 @@ using namespace std::chrono_literals;
 
 
 std::map<int8_t, std::string> pbsrv_enum2str = {{0, "OK"},
-                                                {-1, "BAD_SOCK"},
-                                                {-2, "BAD_OPTS"},
-                                                {-3, "BAD_INPUT"}};
+  {-1, "BAD_SOCK"},
+  {-2, "BAD_OPTS"},
+  {-3, "BAD_INPUT"}};
 
 
 struct PBTorqueControlPolicy
@@ -54,41 +54,41 @@ struct PBTorqueControlPolicy
   JustInterp::LinearInterpolator<float> interp1d;
 
   PBTorqueControlPolicy()
-   : Torque_constant(0.438F),
-     N_Spec{0.0F, 300.0F, 600.0F, 1000.0F, 1700.0F, 4400.0F, 6790.0F},
-     Torque_Spec{0.0F, 0.0F, 0.8F, 2.9F, 5.6F, 9.8F, 16.6F},  // Matches old boost converter
+  : Torque_constant(0.438F),
+    N_Spec{0.0F, 300.0F, 600.0F, 1000.0F, 1700.0F, 4400.0F, 6790.0F},
+    Torque_Spec{0.0F, 0.0F, 0.8F, 2.9F, 5.6F, 9.8F, 16.6F},   // Matches old boost converter
                                                               // targets that have been deployed.
-     I_Spec(Torque_Spec.size(), 0.0F)
+    I_Spec(Torque_Spec.size(), 0.0F)
   {
     update_params();
   }
 
   void update_params()
   {
-    std::transform(Torque_Spec.cbegin(), Torque_Spec.cend(),
-                   I_Spec.begin(),
-                   [tc = Torque_constant](const float &ts){ return ts/tc; });
+    std::transform(
+      Torque_Spec.cbegin(), Torque_Spec.cend(),
+      I_Spec.begin(),
+      [tc = Torque_constant](const float & ts) {return ts / tc;});
 
     interp1d.SetData(N_Spec, I_Spec);
   }
 
-  float WindingCurrentTarget(const float &rpm,
-                             const float &scale_factor,
-                             const float &retract_factor)
+  float WindingCurrentTarget(
+    const float & rpm,
+    const float & scale_factor,
+    const float & retract_factor)
   {
     float N = fabs(rpm);
     float I = 0.0F;
 
-    if (N >= N_Spec.back())
-    {
+    if (N >= N_Spec.back()) {
       I = I_Spec.back();
     } else {
       I = interp1d(N);
     }
 
     I *= scale_factor;
-    if (rpm > 0.0F)
-    {
+    if (rpm > 0.0F) {
       I *= -retract_factor;
     }
 
@@ -96,28 +96,31 @@ struct PBTorqueControlPolicy
   }
 };
 
-std::ostream& operator<<(std::ostream& os, const PBTorqueControlPolicy &policy)
+std::ostream & operator<<(std::ostream & os, const PBTorqueControlPolicy & policy)
 {
   os << "PBTorqueControlPolicy:" << std::endl;
 
   os << "\tTorque_constant: " << policy.Torque_constant << std::endl;
 
   os << "\tN_Spec: " << std::flush;
-  std::copy(policy.N_Spec.cbegin(),
-            policy.N_Spec.cend(),
-            std::ostream_iterator<float>(os, ","));
+  std::copy(
+    policy.N_Spec.cbegin(),
+    policy.N_Spec.cend(),
+    std::ostream_iterator<float>(os, ","));
   os << "\b \b" << std::endl;
 
   os << "\tTorque_Spec: " << std::flush;
-  std::copy(policy.Torque_Spec.cbegin(),
-            policy.Torque_Spec.cend(),
-            std::ostream_iterator<float>(os, ","));
+  std::copy(
+    policy.Torque_Spec.cbegin(),
+    policy.Torque_Spec.cend(),
+    std::ostream_iterator<float>(os, ","));
   os << "\b \b" << std::endl;
 
   os << "\tI_Spec: " << std::flush;
-  std::copy(policy.I_Spec.cbegin(),
-            policy.I_Spec.cend(),
-            std::ostream_iterator<float>(os, ","));
+  std::copy(
+    policy.I_Spec.cbegin(),
+    policy.I_Spec.cend(),
+    std::ostream_iterator<float>(os, ","));
   os << "\b \b" << std::endl;
 
   return os;
@@ -127,9 +130,9 @@ class PBTorqueController : public rclcpp::Node
 {
 public:
   PBTorqueController()
-    : Node("pb_torque_controller"),
-      sub_count_(0U),
-      cmd_count_(0U)
+  : Node("pb_torque_controller"),
+    sub_count_(0U),
+    cmd_count_(0U)
   {
     set_params();
 
@@ -141,33 +144,33 @@ public:
     bool found = wait_for_service(pack_rate_client_, "/pc_pack_rate_command");
     found &= wait_for_service(wind_curr_client_, "/pc_wind_curr_command");
 
-    if (!found)
-    {
+    if (!found) {
       RCLCPP_ERROR(rclcpp::get_logger("pb_torque_controller"), "Did not find required services");
       return;
     }
     set_pc_pack_rate();
 
-    power_data_sub_ = this->create_subscription<buoy_msgs::msg::PCRecord>("/power_data", 1,
-        std::bind(&PBTorqueController::rpm_callback, this, _1));
+    power_data_sub_ = this->create_subscription<buoy_msgs::msg::PCRecord>(
+      "/power_data", 1,
+      std::bind(&PBTorqueController::rpm_callback, this, _1));
   }
 
 private:
-  template <class T>
-  bool wait_for_service(T &client, const std::string &service)
+  template<class T>
+  bool wait_for_service(T & client, const std::string & service)
   {
-    while (!client->wait_for_service(1s))
-    {
-      if (!rclcpp::ok())
-      {
-        RCLCPP_ERROR(rclcpp::get_logger("pb_torque_controller"),
-                     "Interrupted while waiting for %s. Exiting.",
-                     service.c_str());
+    while (!client->wait_for_service(1s)) {
+      if (!rclcpp::ok()) {
+        RCLCPP_ERROR(
+          rclcpp::get_logger("pb_torque_controller"),
+          "Interrupted while waiting for %s. Exiting.",
+          service.c_str());
         return false;
       }
-      RCLCPP_INFO(rclcpp::get_logger("pb_torque_controller"),
-                  "%s not available, still waiting...",
-                  service.c_str());
+      RCLCPP_INFO(
+        rclcpp::get_logger("pb_torque_controller"),
+        "%s not available, still waiting...",
+        service.c_str());
     }
     return true;
   }
@@ -177,13 +180,17 @@ private:
     this->declare_parameter("Torque_constant", policy_.Torque_constant);
     policy_.Torque_constant = this->get_parameter("Torque_constant").as_double();
 
-    this->declare_parameter("N_Spec", std::vector<double>(policy_.N_Spec.begin(),
-                                                          policy_.N_Spec.end()));
+    this->declare_parameter(
+      "N_Spec", std::vector<double>(
+        policy_.N_Spec.begin(),
+        policy_.N_Spec.end()));
     std::vector<double> temp_double_arr = this->get_parameter("N_Spec").as_double_array();
     policy_.N_Spec.assign(temp_double_arr.begin(), temp_double_arr.end());
 
-    this->declare_parameter("Torque_Spec", std::vector<double>(policy_.Torque_Spec.begin(),
-                                                               policy_.Torque_Spec.end()));
+    this->declare_parameter(
+      "Torque_Spec", std::vector<double>(
+        policy_.Torque_Spec.begin(),
+        policy_.Torque_Spec.end()));
     temp_double_arr = this->get_parameter("Torque_Spec").as_double_array();
     policy_.Torque_Spec.assign(temp_double_arr.begin(), temp_double_arr.end());
 
@@ -199,35 +206,39 @@ private:
     using RateServiceResponseFuture = \
       rclcpp::Client<buoy_msgs::srv::PCPackRateCommand>::SharedFuture;
     auto pack_rate_response_callback = [this](RateServiceResponseFuture future)
-    {
-      if (future.get()->result.value == future.get()->result.OK)
       {
-        RCLCPP_INFO(rclcpp::get_logger("pb_torque_controller"),
-                    "Successfully set /pc_pack_rate_command to 50Hz");
-        this->cmd_start_ = this->sub_start_ = this->now();
-      } else {
-        RCLCPP_ERROR(rclcpp::get_logger("pb_torque_controller"),
-                     "Failed to set /pc_pack_rate_command to 50Hz: received error code [[ %s ]]",
-                     pbsrv_enum2str[future.get()->result.value].c_str());
-        // TODO(andermi): should we shutdown?
-      }
-    };
+        if (future.get()->result.value == future.get()->result.OK) {
+          RCLCPP_INFO(
+            rclcpp::get_logger("pb_torque_controller"),
+            "Successfully set /pc_pack_rate_command to 50Hz");
+          this->cmd_start_ = this->sub_start_ = this->now();
+        } else {
+          RCLCPP_ERROR(
+            rclcpp::get_logger("pb_torque_controller"),
+            "Failed to set /pc_pack_rate_command to 50Hz: received error code [[ %s ]]",
+            pbsrv_enum2str[future.get()->result.value].c_str());
+          // TODO(andermi): should we shutdown?
+        }
+      };
 
     auto response = pack_rate_client_->async_send_request(request, pack_rate_response_callback);
   }
 
-  void rpm_callback(const buoy_msgs::msg::PCRecord &power)
+  void rpm_callback(const buoy_msgs::msg::PCRecord & power)
   {
     this->hz(std::string("feedback_rate"), sub_count_, sub_start_);
 
     const float I = policy_.WindingCurrentTarget(power.rpm, power.scale, power.retract);
 
-    RCLCPP_INFO_STREAM(rclcpp::get_logger("pb_torque_controller"),
-                       "power_data -- rpm: " << power.rpm);
-    RCLCPP_INFO_STREAM(rclcpp::get_logger("pb_torque_controller"),
-                       "power_data -- I: " << power.target_a);
-    RCLCPP_INFO_STREAM(rclcpp::get_logger("pb_torque_controller"),
-                       "torque_controller -- I: " << I);
+    RCLCPP_INFO_STREAM(
+      rclcpp::get_logger("pb_torque_controller"),
+      "power_data -- rpm: " << power.rpm);
+    RCLCPP_INFO_STREAM(
+      rclcpp::get_logger("pb_torque_controller"),
+      "power_data -- I: " << power.target_a);
+    RCLCPP_INFO_STREAM(
+      rclcpp::get_logger("pb_torque_controller"),
+      "torque_controller -- I: " << I);
 
     auto request = std::make_shared<buoy_msgs::srv::PCWindCurrCommand::Request>();
     request->wind_curr = I;
@@ -235,35 +246,36 @@ private:
     using WindCurrServiceResponseFuture = \
       rclcpp::Client<buoy_msgs::srv::PCWindCurrCommand>::SharedFuture;
     auto wind_curr_response_callback = [this](WindCurrServiceResponseFuture future)
-    {
-      if (future.get()->result.value == future.get()->result.OK)
       {
-        RCLCPP_INFO(rclcpp::get_logger("pb_torque_controller"),
-                    "Successfully set /pc_wind_curr_command");
-        this->hz(std::string("command_rate"), cmd_count_, cmd_start_);
-      } else {
-        RCLCPP_INFO(rclcpp::get_logger("pb_torque_controller"),
-                    "Failed to set /pc_wind_curr_command: received error code [[ %s ]]",
-                    pbsrv_enum2str[future.get()->result.value].c_str());
-        // TODO(andermi): should we shutdown?
-      }
-    };
+        if (future.get()->result.value == future.get()->result.OK) {
+          RCLCPP_INFO(
+            rclcpp::get_logger("pb_torque_controller"),
+            "Successfully set /pc_wind_curr_command");
+          this->hz(std::string("command_rate"), cmd_count_, cmd_start_);
+        } else {
+          RCLCPP_INFO(
+            rclcpp::get_logger("pb_torque_controller"),
+            "Failed to set /pc_wind_curr_command: received error code [[ %s ]]",
+            pbsrv_enum2str[future.get()->result.value].c_str());
+          // TODO(andermi): should we shutdown?
+        }
+      };
 
     auto response = wind_curr_client_->async_send_request(request, wind_curr_response_callback);
   }
 
-  void hz(const std::string &type, uint16_t &count, rclcpp::Time &start)
+  void hz(const std::string & type, uint16_t & count, rclcpp::Time & start)
   {
     count += 1U;
-    if(count % 500U == 0U)
-    {
+    if (count % 500U == 0U) {
       count = 0U;
       start = this->now();
     } else {
       rclcpp::Time now = this->now();
-      float elapsed_sec = ((now-start).nanoseconds()/1e9);
-      RCLCPP_INFO_STREAM(rclcpp::get_logger("pb_torque_controller"),
-                         type << " : " << count/elapsed_sec);
+      float elapsed_sec = ((now - start).nanoseconds() / 1e9);
+      RCLCPP_INFO_STREAM(
+        rclcpp::get_logger("pb_torque_controller"),
+        type << " : " << count / elapsed_sec);
     }
   }
 
@@ -276,7 +288,7 @@ private:
   rclcpp::Client<buoy_msgs::srv::PCWindCurrCommand>::SharedPtr wind_curr_client_;
 };
 
-int main(int argc, char **argv)
+int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
 


### PR DESCRIPTION
* Ignore `JustInterp` for cpplint with `CPPLINT.cfg` and for uncrustify with `INDENT-OFF` / `INDENT-ON`
* Fix remaining flake8 and uncrustify warnings on other files

With this PR, `colcon test` passes for this package:

```
Label Time Summary:
copyright     =   0.40 sec*proc (1 test)
cppcheck      =   0.19 sec*proc (1 test)
cpplint       =   0.20 sec*proc (1 test)
flake8        =   0.24 sec*proc (1 test)
lint_cmake    =   0.16 sec*proc (1 test)
linter        =   1.93 sec*proc (8 tests)
pep257        =   0.18 sec*proc (1 test)
uncrustify    =   0.18 sec*proc (1 test)
xmllint       =   0.39 sec*proc (1 test)
```

