### PR TITLE
updates from buoy_msgs reorg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,11 +9,12 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclpy REQUIRED)
-find_package(buoy_msgs REQUIRED)
+find_package(buoy_interfaces REQUIRED)
+find_package(buoy_api_cpp REQUIRED)
 find_package(std_msgs REQUIRED)
 
 add_executable(torque_controller src/torque_controller.cpp)
-ament_target_dependencies(torque_controller rclcpp buoy_msgs)
+ament_target_dependencies(torque_controller rclcpp buoy_interfaces buoy_api_cpp)
 target_include_directories(torque_controller PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)

--- a/buoy_examples/bias_damping.py
+++ b/buoy_examples/bias_damping.py
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from buoy_msgs.interface import Interface
-from buoy_msgs.srv import PCBiasCurrCommand
+from buoy_api import Interface
+from buoy_interfaces.srv import PCBiasCurrCommand
 import rclpy
 from scipy import interpolate
 

--- a/buoy_examples/torque_controller.py
+++ b/buoy_examples/torque_controller.py
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from buoy_msgs.interface import Interface
-from buoy_msgs.srv import PCWindCurrCommand
+from buoy_api import Interface
+from buoy_interfaces.srv import PCWindCurrCommand
 import numpy as np
 import rclpy
 from scipy import interpolate

--- a/include/buoy_examples/torque_controller.hpp
+++ b/include/buoy_examples/torque_controller.hpp
@@ -15,11 +15,10 @@
 #ifndef BUOY_EXAMPLES__TORQUE_CONTROLLER_HPP_
 #define BUOY_EXAMPLES__TORQUE_CONTROLLER_HPP_
 
-
-#include <string>
-#include <memory>
-
 #include <buoy_api/interface.hpp>
+
+#include <memory>
+#include <string>
 
 
 // forward declare

--- a/include/buoy_examples/torque_controller.hpp
+++ b/include/buoy_examples/torque_controller.hpp
@@ -19,13 +19,13 @@
 #include <string>
 #include <memory>
 
-#include "buoy_msgs/interface.hpp"
+#include <buoy_api/interface.hpp>
 
 
 // forward declare
 struct PBTorqueControlPolicy;  // defined by user in torque_control_policy.hpp
 
-class PBTorqueController final : public buoy_msgs::Interface<PBTorqueController>
+class PBTorqueController final : public buoy_api::Interface<PBTorqueController>
 {
 public:
   explicit PBTorqueController(const std::string & node_name);
@@ -35,7 +35,7 @@ private:
   friend CRTP;  // syntactic sugar (see https://stackoverflow.com/a/58435857/9686600)
 
   void set_params() final;  // defined by user in torque_control_policy.hpp
-  void power_callback(const buoy_msgs::msg::PCRecord & data);
+  void power_callback(const buoy_interfaces::msg::PCRecord & data);
 
   std::unique_ptr<PBTorqueControlPolicy> policy_;
 };

--- a/package.xml
+++ b/package.xml
@@ -12,7 +12,8 @@
   
   <depend>rclcpp</depend>
   <depend>rclpy</depend>
-  <depend>buoy_msgs</depend>
+  <depend>buoy_interfaces</depend>
+  <depend>buoy_api_cpp</depend>
   <depend>std_msgs</depend>
 
   <exec_depend>python3-scipy</exec_depend>

--- a/src/torque_controller.cpp
+++ b/src/torque_controller.cpp
@@ -21,7 +21,7 @@
 
 
 PBTorqueController::PBTorqueController(const std::string & node_name)
-: buoy_msgs::Interface<PBTorqueController>(node_name)
+: buoy_api::Interface<PBTorqueController>(node_name)
 {
   policy_.reset(new PBTorqueControlPolicy());
   set_params();
@@ -29,9 +29,9 @@ PBTorqueController::PBTorqueController(const std::string & node_name)
   set_pc_pack_rate_param();
 }
 
-void PBTorqueController::power_callback(const buoy_msgs::msg::PCRecord & data)
+void PBTorqueController::power_callback(const buoy_interfaces::msg::PCRecord & data)
 {
-  auto request = std::make_shared<buoy_msgs::srv::PCWindCurrCommand::Request>();
+  auto request = std::make_shared<buoy_interfaces::srv::PCWindCurrCommand::Request>();
   request->wind_curr = policy_->WindingCurrentTarget(data.rpm, data.scale, data.retract);
 
   RCLCPP_INFO_STREAM(


### PR DESCRIPTION
updates from https://github.com/osrf/buoy_msgs/pull/23

`buoy_examples` is no longer necessary as I've moved the examples to `buoy_msgs`. Specifically, `buoy_api_cpp` and `buoy_api_py`

However, I did leave this in working condition with the reorganized `buoy_msgs` repo branch